### PR TITLE
The geocoder lib it's mandatory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "willdurand/geocoder": "*"
     },
     "require-dev": {
-        "kriswallsmith/buzz": "*",
-        "willdurand/geocoder": "*"
+        "kriswallsmith/buzz": "*"
     },
     "suggest": {
         "kriswallsmith/buzz": "Allows to use direction service",


### PR DESCRIPTION
At this moment it seems, that it's mandatory have it

https://github.com/egeloen/ivory-google-map/blob/master/src/Ivory/GoogleMap/Services/Geocoding/Geocoder.php#L14

```
"willdurand/geocoder": "*"
```
