### PR TITLE
Added method chaining support

### DIFF
--- a/src/Ivory/GoogleMap/Map.php
+++ b/src/Ivory/GoogleMap/Map.php
@@ -240,7 +240,7 @@ class Map extends AbstractJavascriptVariableAsset
     /**
      * Gets the map center.
      *
-     * @return Ivroy\GoogleMap\Base\Coordinate The map center.
+     * @return \Ivory\GoogleMap\Base\Coordinate The map center.
      */
     public function getCenter()
     {
@@ -279,7 +279,7 @@ class Map extends AbstractJavascriptVariableAsset
     /**
      * Gets the map bound.
      *
-     * @return Ivory\GoogleMap\Base\Bound The map bound.
+     * @return \Ivory\GoogleMap\Base\Bound The map bound.
      */
     public function getBound()
     {
@@ -934,7 +934,7 @@ class Map extends AbstractJavascriptVariableAsset
     /**
      * Gets the map event manager.
      *
-     * @return Ivory\GoogleMap\Events\EventManager The map event manager.
+     * @return \Ivory\GoogleMap\Events\EventManager The map event manager.
      */
     public function getEventManager()
     {


### PR DESCRIPTION
Method chaining is now possible, added "return $this" to all "get" and "add" methods.

example:

$map->setAsync(true)
            ->setAutoZoom(true)
            ->setCenter(0, 0, true)
            ->setMapOption('zoom', 3);
