### PR TITLE
[Helper] Fix map language with google loader

### DIFF
--- a/src/Ivory/GoogleMap/Helper/ApiHelper.php
+++ b/src/Ivory/GoogleMap/Helper/ApiHelper.php
@@ -59,20 +59,16 @@ class ApiHelper
         $this->loaded = true;
 
         $otherParameters = !empty($libraries) ? sprintf('libraries=%s&', implode(',', $libraries)) : null;
+        $otherParameters .= sprintf('language=%s&', $language);
         $otherParameters .= sprintf('sensor=%s', $sensor ? 'true' : 'false');
 
-        $options = array(
-            'language'     => $language,
-            'other_params' => $otherParameters,
-        );
-
-        $jsonOptions = substr(json_encode($options), 0, -1);
+        $jsonOptions = substr(json_encode(array('other_params' => $otherParameters)), 0, -1);
 
         if ($callback !== null) {
-            $jsonOptions .= sprintf(', "callback": %s}', $callback);
-        } else {
-            $jsonOptions .= '}';
+            $jsonOptions .= sprintf(', "callback": %s', $callback);
         }
+
+        $jsonOptions .= '}';
 
         $loader = sprintf('google.load("maps", "3", %s);', $jsonOptions);
 

--- a/tests/Ivory/Tests/GoogleMap/Helper/ApiHelperTest.php
+++ b/tests/Ivory/Tests/GoogleMap/Helper/ApiHelperTest.php
@@ -48,7 +48,7 @@ class ApiHelperTest extends \PHPUnit_Framework_TestCase
     {
         $expected = <<<EOF
 <script type="text/javascript">
-function load_ivory_google_map_api () { google.load("maps", "3", {"language":"en","other_params":"sensor=false"}); };
+function load_ivory_google_map_api () { google.load("maps", "3", {"other_params":"language=en&sensor=false"}); };
 </script>
 <script type="text/javascript" src="//www.google.com/jsapi?callback=load_ivory_google_map_api"></script>
 
@@ -61,7 +61,7 @@ EOF;
     {
         $expected = <<<EOF
 <script type="text/javascript">
-function load_ivory_google_map_api () { google.load("maps", "3", {"language":"fr","other_params":"sensor=false"}); };
+function load_ivory_google_map_api () { google.load("maps", "3", {"other_params":"language=fr&sensor=false"}); };
 </script>
 <script type="text/javascript" src="//www.google.com/jsapi?callback=load_ivory_google_map_api"></script>
 
@@ -74,7 +74,7 @@ EOF;
     {
         $expected = <<<EOF
 <script type="text/javascript">
-function load_ivory_google_map_api () { google.load("maps", "3", {"language":"en","other_params":"sensor=false"}); };
+function load_ivory_google_map_api () { google.load("maps", "3", {"other_params":"language=en&sensor=false"}); };
 </script>
 <script type="text/javascript" src="//www.google.com/jsapi?callback=load_ivory_google_map_api"></script>
 
@@ -87,7 +87,7 @@ EOF;
     {
         $expected = <<<EOF
 <script type="text/javascript">
-function load_ivory_google_map_api () { google.load("maps", "3", {"language":"en","other_params":"libraries=geometry,places&sensor=false"}); };
+function load_ivory_google_map_api () { google.load("maps", "3", {"other_params":"libraries=geometry,places&language=en&sensor=false"}); };
 </script>
 <script type="text/javascript" src="//www.google.com/jsapi?callback=load_ivory_google_map_api"></script>
 
@@ -100,7 +100,7 @@ EOF;
     {
         $expected = <<<EOF
 <script type="text/javascript">
-function load_ivory_google_map_api () { google.load("maps", "3", {"language":"en","other_params":"sensor=false", "callback": callback}); };
+function load_ivory_google_map_api () { google.load("maps", "3", {"other_params":"language=en&sensor=false", "callback": callback}); };
 </script>
 <script type="text/javascript" src="//www.google.com/jsapi?callback=load_ivory_google_map_api"></script>
 
@@ -113,7 +113,7 @@ EOF;
     {
         $expected = <<<EOF
 <script type="text/javascript">
-function load_ivory_google_map_api () { google.load("maps", "3", {"language":"en","other_params":"sensor=true"}); };
+function load_ivory_google_map_api () { google.load("maps", "3", {"other_params":"language=en&sensor=true"}); };
 </script>
 <script type="text/javascript" src="//www.google.com/jsapi?callback=load_ivory_google_map_api"></script>
 

--- a/tests/Ivory/Tests/GoogleMap/Helper/MapHelperTest.php
+++ b/tests/Ivory/Tests/GoogleMap/Helper/MapHelperTest.php
@@ -1001,7 +1001,7 @@ EOF;
 
         $expected = <<<EOF
 <script type="text/javascript">
-function load_ivory_google_map_api () { google.load("maps", "3", {"language":"en","other_params":"sensor=false"}); };
+function load_ivory_google_map_api () { google.load("maps", "3", {"other_params":"language=en&sensor=false"}); };
 </script>
 <script type="text/javascript" src="//www.google.com/jsapi?callback=load_ivory_google_map_api"></script>
 <script type="text/javascript">
@@ -1029,7 +1029,7 @@ EOF;
 
         $expected = <<<EOF
 <script type="text/javascript">
-function load_ivory_google_map_api () { google.load("maps", "3", {"language":"en","other_params":"libraries=geometry&sensor=false"}); };
+function load_ivory_google_map_api () { google.load("maps", "3", {"other_params":"libraries=geometry&language=en&sensor=false"}); };
 </script>
 <script type="text/javascript" src="//www.google.com/jsapi?callback=load_ivory_google_map_api"></script>
 <script type="text/javascript">
@@ -1055,7 +1055,7 @@ EOF;
 
         $expected = <<<EOF
 <script type="text/javascript">
-function load_ivory_google_map_api () { google.load("maps", "3", {"language":"en","other_params":"libraries=places&sensor=false"}); };
+function load_ivory_google_map_api () { google.load("maps", "3", {"other_params":"libraries=places&language=en&sensor=false"}); };
 </script>
 <script type="text/javascript" src="//www.google.com/jsapi?callback=load_ivory_google_map_api"></script>
 <script type="text/javascript">
@@ -1088,7 +1088,7 @@ map.setCenter(map_center);
 }
 </script>
 <script type="text/javascript">
-function load_ivory_google_map_api () { google.load("maps", "3", {"language":"en","other_params":"sensor=false", "callback": load_ivory_google_map}); };
+function load_ivory_google_map_api () { google.load("maps", "3", {"other_params":"language=en&sensor=false", "callback": load_ivory_google_map}); };
 </script>
 <script type="text/javascript" src="//www.google.com/jsapi?callback=load_ivory_google_map_api"></script>
 
@@ -1105,7 +1105,7 @@ EOF;
 
         $expected1 = <<<EOF
 <script type="text/javascript">
-function load_ivory_google_map_api () { google.load("maps", "3", {"language":"en","other_params":"sensor=false"}); };
+function load_ivory_google_map_api () { google.load("maps", "3", {"other_params":"language=en&sensor=false"}); };
 </script>
 <script type="text/javascript" src="//www.google.com/jsapi?callback=load_ivory_google_map_api"></script>
 <script type="text/javascript">
@@ -1151,7 +1151,7 @@ height:300px;
 }
 </style>
 <script type="text/javascript">
-function load_ivory_google_map_api () { google.load("maps", "3", {"language":"en","other_params":"sensor=false"}); };
+function load_ivory_google_map_api () { google.load("maps", "3", {"other_params":"language=en&sensor=false"}); };
 </script>
 <script type="text/javascript" src="//www.google.com/jsapi?callback=load_ivory_google_map_api"></script>
 <script type="text/javascript">

--- a/tests/Ivory/Tests/GoogleMap/Helper/Places/AutocompleteHelperTest.php
+++ b/tests/Ivory/Tests/GoogleMap/Helper/Places/AutocompleteHelperTest.php
@@ -166,7 +166,7 @@ EOF;
 
         $expected = <<<EOF
 <script type="text/javascript">
-function load_ivory_google_map_api () { google.load("maps", "3", {"language":"en","other_params":"libraries=places&sensor=false"}); };
+function load_ivory_google_map_api () { google.load("maps", "3", {"other_params":"libraries=places&language=en&sensor=false"}); };
 </script>
 <script type="text/javascript" src="//www.google.com/jsapi?callback=load_ivory_google_map_api"></script>
 <script type="text/javascript">
@@ -188,7 +188,7 @@ EOF;
 
         $expected1 = <<<EOF
 <script type="text/javascript">
-function load_ivory_google_map_api () { google.load("maps", "3", {"language":"en","other_params":"libraries=places&sensor=false"}); };
+function load_ivory_google_map_api () { google.load("maps", "3", {"other_params":"libraries=places&language=en&sensor=false"}); };
 </script>
 <script type="text/javascript" src="//www.google.com/jsapi?callback=load_ivory_google_map_api"></script>
 <script type="text/javascript">
@@ -220,7 +220,7 @@ EOF;
 
         $expected = <<<EOF
 <script type="text/javascript">
-function load_ivory_google_map_api () { google.load("maps", "3", {"language":"en","other_params":"libraries=places&sensor=false"}); };
+function load_ivory_google_map_api () { google.load("maps", "3", {"other_params":"libraries=places&language=en&sensor=false"}); };
 </script>
 <script type="text/javascript" src="//www.google.com/jsapi?callback=load_ivory_google_map_api"></script>
 <script type="text/javascript">
@@ -248,7 +248,7 @@ autocomplete = new google.maps.places.Autocomplete(document.getElementById('plac
 }
 </script>
 <script type="text/javascript">
-function load_ivory_google_map_api () { google.load("maps", "3", {"language":"en","other_params":"libraries=places&sensor=false", "callback": load_ivory_google_place}); };
+function load_ivory_google_map_api () { google.load("maps", "3", {"other_params":"libraries=places&language=en&sensor=false", "callback": load_ivory_google_place}); };
 </script>
 <script type="text/javascript" src="//www.google.com/jsapi?callback=load_ivory_google_map_api"></script>
 


### PR DESCRIPTION
This PR fixes egeloen/IvoryGoogleMapBundle#76 by defining the language as `other_params` & not as a dedicated optional settings... Thx to @pmeier82 which points out the fact the official google loader doc is outdated...
