### PR TITLE
PropertyAccess::createPropertyAccessor() doesn't work with Symfony 2.2

### DIFF
--- a/src/Ivory/GoogleMap/Helper/Utils/JsonBuilder.php
+++ b/src/Ivory/GoogleMap/Helper/Utils/JsonBuilder.php
@@ -11,7 +11,7 @@
 
 namespace Ivory\GoogleMap\Helper\Utils;
 
-use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
 
 /**
  * Json builder.
@@ -37,7 +37,7 @@ class JsonBuilder
      */
     public function __construct()
     {
-        $this->accessor = PropertyAccess::createPropertyAccessor();
+        $this->accessor = new PropertyAccessor();
 
         $this->reset();
     }


### PR DESCRIPTION
`PropertyAccess::createPropertyAccessor()` only works with Symfony 2.3, I'd suggest to use `PropertyAccess::getPropertyAccessor()` (which works in both s2.2 and s2.3) until Symfony 3.0 becomes available.

http://symfony.com/doc/current/components/property_access/introduction.html#usage
https://github.com/symfony/PropertyAccess/blob/master/PropertyAccess.php#L46
