### PR TITLE
Services request language can now have 2 or 5 characteres.

### DIFF
--- a/src/Ivory/GoogleMap/Exception/DirectionsException.php
+++ b/src/Ivory/GoogleMap/Exception/DirectionsException.php
@@ -166,7 +166,7 @@ class DirectionsException extends ServiceException
      */
     public static function invalidDirectionsRequestLanguage()
     {
-        return new static('The directions request language must be a string with two characters.');
+        return new static('The directions request language must be a string with two or five characters.');
     }
 
     /**

--- a/src/Ivory/GoogleMap/Exception/DistanceMatrixException.php
+++ b/src/Ivory/GoogleMap/Exception/DistanceMatrixException.php
@@ -101,7 +101,7 @@ class DistanceMatrixException extends ServiceException
      */
     public static function invalidDistanceMatrixRequestLanguage()
     {
-        return new static('The distance matrix request language must be a string with two characters.');
+        return new static('The distance matrix request language must be a string with two or five characters.');
     }
 
     /**

--- a/src/Ivory/GoogleMap/Exception/GeocodingException.php
+++ b/src/Ivory/GoogleMap/Exception/GeocodingException.php
@@ -196,7 +196,7 @@ class GeocodingException extends ServiceException
      */
     public static function invalidGeocoderRequestLanguage()
     {
-        return new static('The geocoder request language must be a string with two characters.');
+        return new static('The geocoder request language must be a string with two or five characters.');
     }
 
     /**

--- a/src/Ivory/GoogleMap/Services/Directions/DirectionsRequest.php
+++ b/src/Ivory/GoogleMap/Services/Directions/DirectionsRequest.php
@@ -453,7 +453,7 @@ class DirectionsRequest
      */
     public function setLanguage($language = null)
     {
-        if ((!is_string($language) || (strlen($language) !== 2)) && ($language !== null)) {
+        if ((!is_string($language) || ((strlen($language) !== 2) && (strlen($language) !== 5))) && ($language !== null)) {
             throw DirectionsException::invalidDirectionsRequestLanguage();
         }
 

--- a/src/Ivory/GoogleMap/Services/DistanceMatrix/DistanceMatrixRequest.php
+++ b/src/Ivory/GoogleMap/Services/DistanceMatrix/DistanceMatrixRequest.php
@@ -333,7 +333,7 @@ class DistanceMatrixRequest
      */
     public function setLanguage($language = null)
     {
-        if ((!is_string($language) || (strlen($language) !== 2)) && ($language !== null)) {
+        if ((!is_string($language) || ((strlen($language) !== 2) && (strlen($language) !== 5))) && ($language !== null)) {
             throw DistanceMatrixException::invalidDistanceMatrixRequestLanguage();
         }
 

--- a/src/Ivory/GoogleMap/Services/Geocoding/GeocoderRequest.php
+++ b/src/Ivory/GoogleMap/Services/Geocoding/GeocoderRequest.php
@@ -283,7 +283,7 @@ class GeocoderRequest
      */
     public function setLanguage($language = null)
     {
-        if ((!is_string($language) || (strlen($language) !== 2)) && ($language !== null)) {
+        if ((!is_string($language) || ((strlen($language) !== 2) && (strlen($language) !== 5))) && ($language !== null)) {
             throw GeocodingException::invalidGeocoderRequestLanguage();
         }
 

--- a/tests/Ivory/Tests/GoogleMap/Services/Directions/DirectionsRequestTest.php
+++ b/tests/Ivory/Tests/GoogleMap/Services/Directions/DirectionsRequestTest.php
@@ -313,7 +313,7 @@ class DirectionsRequestTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Ivory\GoogleMap\Exception\DirectionsException
-     * @expectedExceptionMessage The directions request language must be a string with two characters.
+     * @expectedExceptionMessage The directions request language must be a string with two or five characters.
      */
     public function testLanguageWithInvalidValue()
     {

--- a/tests/Ivory/Tests/GoogleMap/Services/DistanceMatrix/DistanceMatrixRequestTest.php
+++ b/tests/Ivory/Tests/GoogleMap/Services/DistanceMatrix/DistanceMatrixRequestTest.php
@@ -240,7 +240,7 @@ class DistanceMatrixRequestTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Ivory\GoogleMap\Exception\DistanceMatrixException
-     * @expectedExceptionMessage The distance matrix request language must be a string with two characters.
+     * @expectedExceptionMessage The distance matrix request language must be a string with two or five characters.
      */
     public function testLanguageWithInvalidValue()
     {

--- a/tests/Ivory/Tests/GoogleMap/Services/Geocoding/GeocoderRequestTest.php
+++ b/tests/Ivory/Tests/GoogleMap/Services/Geocoding/GeocoderRequestTest.php
@@ -217,7 +217,7 @@ class GeocoderRequestTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Ivory\GoogleMap\Exception\GeocodingException
-     * @expectedExceptionMessage The geocoder request language must be a string with two characters.
+     * @expectedExceptionMessage The geocoder request language must be a string with two or five characters.
      */
     public function testLanguageWithInvalidValue()
     {


### PR DESCRIPTION
According to the [Google Maps API Coverage Spreadsheet](https://spreadsheets.google.com/pub?key=p9pdwsai2hDMsLkXsoM05KQ&gid=1) (link took from the API docs), language codes can have 2 or 5 chars.
