### PR TITLE
Installation via composer error solved

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "symfony/property-access": "2.*"
+        "symfony/property-access": "2.4.*"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",


### PR DESCRIPTION
Referenced Issue #61
I was getting the following error while installing this component with Composer.

``` bash
 [Composer\Downloader\TransportException]                                     
  The "https://api.github.com/repos/symfony/PropertyAccess/zipball/2749512341  
  50e303c83099a2429be6be35629fe9" file could not be downloaded (HTTP/1.0 500   
  Internal Server Error)     
```

And when I tried to put `https://api.github.com/repos/symfony/PropertyAccess/zipball/2749512341  
  50e303c83099a2429be6be35629fe9` url in browser then also it shows **Internal Server Error**. I think in your `composer.json` file should be updated for symfony/propertyaccess dependency module.

now this little change solve the error
