### PR TITLE
Updated to use widop/http-adapter version 1.1+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
-        "widop/http-adapter": "~1.0,<1.1",
+        "widop/http-adapter": "~1.1",
         "willdurand/geocoder": "~2.0",
         "satooshi/php-coveralls": "~0.6"
     },

--- a/src/Ivory/GoogleMap/Services/Directions/Directions.php
+++ b/src/Ivory/GoogleMap/Services/Directions/Directions.php
@@ -72,7 +72,7 @@ class Directions extends AbstractService
             throw DirectionsException::invalidServiceResult();
         }
 
-        $directionsResponse = $this->buildDirectionsResponse($this->parse($response));
+        $directionsResponse = $this->buildDirectionsResponse($this->parse($response->getBody()));
 
         return $directionsResponse;
     }

--- a/src/Ivory/GoogleMap/Services/DistanceMatrix/DistanceMatrix.php
+++ b/src/Ivory/GoogleMap/Services/DistanceMatrix/DistanceMatrix.php
@@ -70,7 +70,7 @@ class DistanceMatrix extends AbstractService
             throw DistanceMatrixException::invalidServiceResult();
         }
 
-        $distanceMatrixResponse = $this->buildDistanceMatrixResponse($this->parse($response));
+        $distanceMatrixResponse = $this->buildDistanceMatrixResponse($this->parse($response->getBody()));
 
         return $distanceMatrixResponse;
     }


### PR DESCRIPTION
This update reflects the change in widop/http-adapter, which now returns an object instead of a string. The call to getBody() on the object returns the old value, thus the additional call to getBody().
