### PR TITLE
Fixed http query used for avoid tolls/highways to match Google API

### DIFF
--- a/src/Services/DistanceMatrix/DistanceMatrix.php
+++ b/src/Services/DistanceMatrix/DistanceMatrix.php
@@ -115,11 +115,11 @@ class DistanceMatrix extends AbstractService
         }
 
         if ($distanceMatrixRequest->hasAvoidTolls() && $distanceMatrixRequest->getAvoidTolls()) {
-            $httpQuery['avoidTolls'] = true;
+            $httpQuery['avoid'] = 'tolls';
         }
 
         if ($distanceMatrixRequest->hasAvoidHighways() && $distanceMatrixRequest->getAvoidHighways()) {
-            $httpQuery['avoidHighways'] = true;
+            $httpQuery['avoid'] = 'highways';
         }
 
         if ($distanceMatrixRequest->hasUnitSystem()) {


### PR DESCRIPTION
Not sure if this is a recent change to the API, but certainly requires this for these options to work with the latest API: https://developers.google.com/maps/documentation/distancematrix/intro