### PR TITLE
Fix W3C validation error

### DIFF
--- a/src/Helper/MapHelper.php
+++ b/src/Helper/MapHelper.php
@@ -896,8 +896,8 @@ class MapHelper extends AbstractHelper
     public function render(Map $map)
     {
         return implode('', array(
-            $this->renderHtmlContainer($map),
             $this->renderStylesheets($map),
+            $this->renderHtmlContainer($map),
             $this->renderJavascripts($map)
         ));
     }
@@ -930,7 +930,7 @@ class MapHelper extends AbstractHelper
     {
         $html = array();
 
-        $html[] = '<style type="text/css">'.PHP_EOL;
+        $html[] = '<style type="text/css" scoped>'.PHP_EOL;
         $html[] = '#'.$map->getHtmlContainerId().'{'.PHP_EOL;
 
         foreach ($map->getStylesheetOptions() as $option => $value) {

--- a/tests/Helper/MapHelperTest.php
+++ b/tests/Helper/MapHelperTest.php
@@ -318,7 +318,7 @@ class MapHelperTest extends \PHPUnit_Framework_TestCase
         $map->setStylesheetOptions(array('width' => '200px','height' => '100px', 'option1' => 'value1'));
 
         $expected = <<<EOF
-<style type="text/css">
+<style type="text/css" scoped>
 #html_container_id{
 width:200px;
 height:100px;
@@ -1255,13 +1255,13 @@ EOF;
         $map->getCenter()->setJavascriptVariable('map_center');
 
         $expected = <<<EOF
-<div id="map_canvas" style="width:300px;height:300px;"></div>
-<style type="text/css">
+<style type="text/css" scoped>
 #map_canvas{
 width:300px;
 height:300px;
 }
 </style>
+<div id="map_canvas" style="width:300px;height:300px;"></div>
 <script type="text/javascript">
 function load_ivory_google_map_api () { google.load("maps", "3", {"other_params":"language=en&sensor=false"}); };
 </script>


### PR DESCRIPTION
Error: "element style not allowed as child of element div in this context. (Suppressing further errors from this subtree.)"

I fixed this error, in my app, with this patch. 

<img width="1150" alt="screen shot 2015-09-11 at 8 42 14 pm" src="https://cloud.githubusercontent.com/assets/5246304/9828555/92b3dc5a-58c5-11e5-8ac9-d143035a987a.png">
