### PR TITLE
Update JsMarkerClusterHelper.php

### DIFF
--- a/src/Helper/Overlays/MarkerCluster/JsMarkerClusterHelper.php
+++ b/src/Helper/Overlays/MarkerCluster/JsMarkerClusterHelper.php
@@ -48,7 +48,7 @@ class JsMarkerClusterHelper extends DefaultMarkerClusterHelper
      */
     public function renderLibraries(MarkerCluster $markerCluster, Map $map)
     {
-        $url = '//google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclusterer/src/markerclusterer_compiled.js';
+        $url = '//rawgit.com/googlemaps/js-marker-clusterer/gh-pages/src/markerclusterer_compiled.js';
 
         return sprintf('<script type="text/javascript" src="%s"></script>'.PHP_EOL, $url);
     }


### PR DESCRIPTION
As Google moved the source over to GitHub a while back, the new hosted versions can now be accessed directly by using the following script urls (standard and compiled versions):