### PR TITLE
Update JsMarkerClusterHelperTest.php

### DIFF
--- a/tests/Helper/Overlays/MarkerCluster/JsMarkerClusterHelperTest.php
+++ b/tests/Helper/Overlays/MarkerCluster/JsMarkerClusterHelperTest.php
@@ -93,7 +93,7 @@ EOF;
         $map = new Map();
 
         $expected = <<<EOF
-<script type="text/javascript" src="//google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclusterer/src/markerclusterer_compiled.js"></script>
+<script type="text/javascript" src="//rawgit.com/googlemaps/js-marker-clusterer/gh-pages/src/markerclusterer_compiled.js"></script>
 
 EOF;
 


### PR DESCRIPTION
As Google moved the source over to GitHub a while back, the new hosted versions can now be accessed directly by using the following script urls: