### PR TITLE
Update InfoBoxExtensionHelper JS library source

### DIFF
--- a/src/Helper/Extension/InfoBoxExtensionHelper.php
+++ b/src/Helper/Extension/InfoBoxExtensionHelper.php
@@ -33,7 +33,7 @@ class InfoBoxExtensionHelper extends AbstractExtensionHelper
      * @param string $callback The info box callback.
      */
     public function __construct(
-        $source = '//google-maps-utility-library-v3.googlecode.com/svn/trunk/infobox/src/infobox_packed.js',
+        $source = '//cdn.rawgit.com/googlemaps/v3-utility-library/master/infobox/src/infobox_packed.js',
         $callback = 'load_ivory_google_map_info_box'
     ) {
         $this->setSource($source);


### PR DESCRIPTION
Move from:

//google-maps-utility-library-v3.googlecode.com/svn/trunk/infobox/src/infobox.js

to:

//cdn.rawgit.com/googlemaps/v3-utility-library/master/infobox/src/infobox_packed.js

As GoogleCode is end of lifed now and returns a 404.

See: http://stackoverflow.com/questions/37171426/google-maps-api-v3-infobox-js-removed for further info.