### PR TITLE
API Key support and fix for Sensor Warning

### DIFF
--- a/src/Helper/ApiHelper.php
+++ b/src/Helper/ApiHelper.php
@@ -54,6 +54,7 @@ class ApiHelper extends AbstractHelper
      * @param array   $libraries Additionnal libraries.
      * @param string  $callback  A JS callback.
      * @param boolean $sensor    The sensor flag.
+     * @param string  $api_key   Google Browser API Key for the map
      *
      * @return string The HTML output.
      */
@@ -61,7 +62,8 @@ class ApiHelper extends AbstractHelper
         $language = 'en',
         array $libraries = array(),
         $callback = null,
-        $sensor = false
+        $sensor = false,
+        $api_key = null
     )
     {
         $otherParameters = array();
@@ -71,7 +73,15 @@ class ApiHelper extends AbstractHelper
         }
 
         $otherParameters['language'] = $language;
-        $otherParameters['sensor'] = json_encode((bool) $sensor);
+
+        // Google Maps API warning: SensorNotRequired https://developers.google.com/maps/documentation/javascript/error-messages#sensor-not-required
+        //$otherParameters['sensor'] = json_encode((bool) $sensor);
+
+        if(!is_null($api_key)){
+            $otherParameters['key'] = $api_key;
+        }else{
+            // Google Maps API warning: NoApiKeys https://developers.google.com/maps/documentation/javascript/error-messages#no-api-keys
+        }
 
         $this->jsonBuilder
             ->reset()

--- a/src/Helper/Extension/CoreExtensionHelper.php
+++ b/src/Helper/Extension/CoreExtensionHelper.php
@@ -105,7 +105,7 @@ class CoreExtensionHelper implements ExtensionHelperInterface
 
         $output = array();
 
-        $output[] = $this->apiHelper->render($map->getLanguage(), $this->getLibraries($map), $callback);
+        $output[] = $this->apiHelper->render($map->getLanguage(), $this->getLibraries($map), $callback, false, $map->getApiKey());
         $output[] = $this->markerClusterHelper->renderLibraries($map->getMarkerCluster(), $map);
 
         return implode('', $output);

--- a/src/Map.php
+++ b/src/Map.php
@@ -120,6 +120,9 @@ class Map extends AbstractJavascriptVariableAsset
     /** @var string */
     protected $language;
 
+    /** @var string */
+    protected $apiKey;
+
     /**
      * Creates a map.
      */
@@ -158,6 +161,7 @@ class Map extends AbstractJavascriptVariableAsset
 
         $this->libraries = array();
         $this->language = 'en';
+        $this->apiKey = null;
     }
 
     /**
@@ -1206,5 +1210,21 @@ class Map extends AbstractJavascriptVariableAsset
     public function setLanguage($language)
     {
         $this->language = $language;
+    }
+
+    /**
+     * @return string The Browser API Key
+     */
+    public function getApiKey()
+    {
+        return $this->apiKey;
+    }
+
+    /**
+     * @param string $apiKey The Browser API Key
+     */
+    public function setApiKey($apiKey)
+    {
+        $this->apiKey = $apiKey;
     }
 }


### PR DESCRIPTION
Added Support for API Key and Address Google Maps warnings
Google Maps API warning: NoApiKeys https://developers.google.com/maps/documentation/javascript/error-messages#no-api-keys
Google Maps API warning: SensorNotRequired https://developers.google.com/maps/documentation/javascript/error-messages#sensor-not-required

Addresses #111
And: https://github.com/egeloen/IvoryGoogleMapBundle/issues/114
