### PR TITLE
Fix typo in PHPDOC

### DIFF
--- a/src/Base/Coordinate.php
+++ b/src/Base/Coordinate.php
@@ -76,7 +76,7 @@ class Coordinate extends AbstractJavascriptVariableAsset
     /**
      * Gets the longitude
      *
-     * @return doube The longitude.
+     * @return double The longitude.
      */
     public function getLongitude()
     {


### PR DESCRIPTION
There is a typo in the Ivory\GoogleMap\Base\Coordinate::getLongitude() return. should be `double` instead of `doube`