### PR TITLE
Move language from map/autocomplete to the renderer

### DIFF
--- a/doc/helper/api.md
+++ b/doc/helper/api.md
@@ -14,9 +14,9 @@ use Ivory\GoogleMap\Helper\Builder\ApiHelperBuilder;
 $apiHelper = ApiHelperBuilder::create()->build();
 ```
 
-The api helper is built via a builder. The builder allows you to configure the helper json builder, formatter and 
-subscribers. The json builder allows to build advanced JSON, the formatter allows to format the generated code and the 
-subscribers allow you to attach additional code to the API.
+The api helper is built via a builder. The builder allows you to configure the helper json builder, formatter, language 
+and subscribers. The json builder allows to build advanced JSON, the formatter allows to format the generated code, the
+language allows to localize the API (default en) and the subscribers allow you to attach additional code to the API.
 
 ``` php
 use Ivory\GoogleMap\Helper\Builder\ApiHelperBuilder;
@@ -26,6 +26,8 @@ $apiHelperBuilder = ApiHelperBuilder::create();
 $apiHelperBuilder->getFormatter()->setDebug(true);
 $apiHelperBuilder->getFormatter()->setIndentationStep(4);
 $apiHelperBuilder->getFormatter()->setDefaultIndentation(0);
+
+$apiHelperBuilder->setLanguage('fr');
 
 $apiHelperBuilder->addSubscriber(/* ... */);
 

--- a/doc/map.md
+++ b/doc/map.md
@@ -106,14 +106,6 @@ all of them. If you need a custom library (for example `drawing`), you can use:
 $map->addLibrary('drawing');
 ```
 
-## Configure language
-
-If you want to use your own language when displaying your map, you can use:
-
-```
-$map->setLanguage('fr');
-```
-
 ## Configure options
 
 The map options allows you to configure additional map aspects. See the list of available options in the Google Map

--- a/doc/place/autocomplete.md
+++ b/doc/place/autocomplete.md
@@ -71,14 +71,6 @@ $autocomplete->setBound(new Bound(
 ));
 ```
 
-## Configure language
-
-If you want to use your own language when displaying your autocomplete, you can use:
-
-``` php
-$autocomplete->setLanguage('fr');
-```
-
 ## Configure libraries
 
 Sometimes, you want to use the autocomplete & other Google Map related libraries. The library provides many 
@@ -98,4 +90,6 @@ $autocomplete->setInputAttribute('class', 'my-class');
 
 ## Render autocomplete
 
+Once you have configured your autocomplete, you can render it:
 
+- [Rendering](/doc/helper/index.md)

--- a/src/Helper/Builder/ApiHelperBuilder.php
+++ b/src/Helper/Builder/ApiHelperBuilder.php
@@ -15,6 +15,7 @@ use Ivory\GoogleMap\Helper\ApiHelper;
 use Ivory\GoogleMap\Helper\Collector\Overlay\EncodedPolylineCollector;
 use Ivory\GoogleMap\Helper\Collector\Overlay\InfoBoxCollector;
 use Ivory\GoogleMap\Helper\Collector\Overlay\MarkerCollector;
+use Ivory\GoogleMap\Helper\Formatter\Formatter;
 use Ivory\GoogleMap\Helper\Renderer\ApiInitRenderer;
 use Ivory\GoogleMap\Helper\Renderer\ApiRenderer;
 use Ivory\GoogleMap\Helper\Renderer\Control\ControlManagerRenderer;
@@ -38,12 +39,46 @@ use Ivory\GoogleMap\Helper\Subscriber\Overlay\EncodedPolylineSubscriber;
 use Ivory\GoogleMap\Helper\Subscriber\Overlay\InfoBoxSubscriber;
 use Ivory\GoogleMap\Helper\Subscriber\Overlay\MarkerClustererSubscriber;
 use Ivory\GoogleMap\Helper\Subscriber\Place\AutocompleteJavascriptSubscriber;
+use Ivory\JsonBuilder\JsonBuilder;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
 class ApiHelperBuilder extends AbstractHelperBuilder
 {
+    /**
+     * @var string
+     */
+    private $language;
+
+    /**
+     * @param Formatter|null   $formatter
+     * @param JsonBuilder|null $jsonBuilder
+     * @param string           $language
+     */
+    public function __construct(Formatter $formatter = null, JsonBuilder $jsonBuilder = null, $language = 'en')
+    {
+        parent::__construct($formatter, $jsonBuilder);
+
+        $this->setLanguage($language);
+    }
+
+    /**
+     * @return string
+     */
+    public function getLanguage()
+    {
+        return $this->language;
+    }
+
+    /**
+     * @param string $language
+     */
+    public function setLanguage($language)
+    {
+        $this->language = $language;
+    }
+
     /**
      * @return ApiHelper
      */
@@ -70,7 +105,7 @@ class ApiHelperBuilder extends AbstractHelperBuilder
 
         // Utility renderers
         $callbackRenderer = new CallbackRenderer($formatter);
-        $loaderRenderer = new LoaderRenderer($formatter, $jsonBuilder);
+        $loaderRenderer = new LoaderRenderer($formatter, $jsonBuilder, $this->language);
         $requirementLoaderRenderer = new RequirementLoaderRenderer($formatter);
         $requirementRenderer = new RequirementRenderer($formatter);
         $sourceRenderer = new SourceRenderer($formatter);

--- a/src/Helper/Event/ApiEvent.php
+++ b/src/Helper/Event/ApiEvent.php
@@ -22,11 +22,6 @@ class ApiEvent extends AbstractEvent
     private $objects;
 
     /**
-     * @var string
-     */
-    private $language = 'en';
-
-    /**
      * @var string[]
      */
     private $sources = [];
@@ -88,22 +83,6 @@ class ApiEvent extends AbstractEvent
         }
 
         return $objects;
-    }
-
-    /**
-     * @return string
-     */
-    public function getLanguage()
-    {
-        return $this->language;
-    }
-
-    /**
-     * @param string $language
-     */
-    public function setLanguage($language)
-    {
-        $this->language = $language;
     }
 
     /**

--- a/src/Helper/Renderer/ApiRenderer.php
+++ b/src/Helper/Renderer/ApiRenderer.php
@@ -127,7 +127,6 @@ class ApiRenderer extends AbstractRenderer
     }
 
     /**
-     * @param string            $language
      * @param \SplObjectStorage $callbacks
      * @param \SplObjectStorage $requirements
      * @param string[]          $sources
@@ -136,7 +135,6 @@ class ApiRenderer extends AbstractRenderer
      * @return string
      */
     public function render(
-        $language,
         \SplObjectStorage $callbacks,
         \SplObjectStorage $requirements,
         array $sources = [],
@@ -150,7 +148,7 @@ class ApiRenderer extends AbstractRenderer
         $initRequirementCallback = $this->getCallbackName('init_requirement');
 
         return $formatter->renderLines([
-            $this->loaderRenderer->render($loadCallback, $initCallback, $language, $libraries, false),
+            $this->loaderRenderer->render($loadCallback, $initCallback, $libraries, false),
             $this->sourceRenderer->render($initSourceCallback, null, null, false),
             $this->requirementLoaderRenderer->render($initRequirementCallback, null, null, null, 100, false),
             $this->apiInitRenderer->render(

--- a/src/Helper/Renderer/LoaderRenderer.php
+++ b/src/Helper/Renderer/LoaderRenderer.php
@@ -11,15 +11,50 @@
 
 namespace Ivory\GoogleMap\Helper\Renderer;
 
+use Ivory\GoogleMap\Helper\Formatter\Formatter;
+use Ivory\JsonBuilder\JsonBuilder;
+
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
 class LoaderRenderer extends AbstractJsonRenderer
 {
     /**
+     * @var string
+     */
+    private $language;
+
+    /**
+     * @param Formatter   $formatter
+     * @param JsonBuilder $jsonBuilder
+     * @param string      $language
+     */
+    public function __construct(Formatter $formatter, JsonBuilder $jsonBuilder, $language = 'en')
+    {
+        parent::__construct($formatter, $jsonBuilder);
+
+        $this->setLanguage($language);
+    }
+
+    /**
+     * @return string
+     */
+    public function getLanguage()
+    {
+        return $this->language;
+    }
+
+    /**
+     * @param string $language
+     */
+    public function setLanguage($language)
+    {
+        $this->language = $language;
+    }
+
+    /**
      * @param string   $name
      * @param string   $callback
-     * @param string   $language
      * @param string[] $libraries
      * @param bool     $newLine
      *
@@ -28,14 +63,13 @@ class LoaderRenderer extends AbstractJsonRenderer
     public function render(
         $name,
         $callback,
-        $language,
         array $libraries = [],
         $newLine = true
     ) {
         $formatter = $this->getFormatter();
         $jsonBuilder = $this->getJsonBuilder();
 
-        $parameters = ['language' => $language];
+        $parameters = ['language' => $this->language];
         if (!empty($libraries)) {
             $parameters['libraries'] = implode(',', $libraries);
         }

--- a/src/Helper/Subscriber/ApiJavascriptSubscriber.php
+++ b/src/Helper/Subscriber/ApiJavascriptSubscriber.php
@@ -113,7 +113,6 @@ class ApiJavascriptSubscriber extends AbstractDelegateSubscriber
     private function handleApi(ApiEvent $event)
     {
         $event->setCode($this->javascriptTagRenderer->render($this->apiRenderer->render(
-            $event->getLanguage(),
             $event->getCallbacks(),
             $event->getRequirements(),
             $event->getSources(),

--- a/src/Helper/Subscriber/MapJavascriptSubscriber.php
+++ b/src/Helper/Subscriber/MapJavascriptSubscriber.php
@@ -149,7 +149,6 @@ class MapJavascriptSubscriber extends AbstractDelegateSubscriber
     private function handleApi(ApiEvent $event)
     {
         foreach ($event->getObjects(Map::class) as $map) {
-            $event->setLanguage($map->getLanguage());
             $event->addLibraries($map->getLibraries());
             $event->addCallback($map, $this->renderCallback($map));
             $event->addRequirement($map, $this->mapRenderer->renderRequirement());

--- a/src/Helper/Subscriber/Place/AutocompleteJavascriptSubscriber.php
+++ b/src/Helper/Subscriber/Place/AutocompleteJavascriptSubscriber.php
@@ -146,7 +146,6 @@ class AutocompleteJavascriptSubscriber extends AbstractDelegateSubscriber
     private function handleApi(ApiEvent $event)
     {
         foreach ($event->getObjects(Autocomplete::class) as $autocomplete) {
-            $event->setLanguage($autocomplete->getLanguage());
             $event->addLibraries(array_unique(array_merge($autocomplete->getLibraries(), ['places'])));
             $event->addCallback($autocomplete, $this->renderCallback($autocomplete));
             $event->addRequirement($autocomplete, $this->autocompleteRenderer->renderRequirement());

--- a/src/Map.php
+++ b/src/Map.php
@@ -75,11 +75,6 @@ class Map implements VariableAwareInterface
     private $libraries = [];
 
     /**
-     * @var string
-     */
-    private $language = 'en';
-
-    /**
      * @var mixed[]
      */
     private $mapOptions = [];
@@ -305,22 +300,6 @@ class Map implements VariableAwareInterface
     public function removeLibrary($library)
     {
         unset($this->libraries[array_search($library, $this->libraries, true)]);
-    }
-
-    /**
-     * @return string
-     */
-    public function getLanguage()
-    {
-        return $this->language;
-    }
-
-    /**
-     * @param string $language
-     */
-    public function setLanguage($language)
-    {
-        $this->language = $language;
     }
 
     /**

--- a/src/Place/Autocomplete.php
+++ b/src/Place/Autocomplete.php
@@ -57,11 +57,6 @@ class Autocomplete implements VariableAwareInterface
      */
     private $libraries = [];
 
-    /**
-     * @var string
-     */
-    private $language = 'en';
-
     public function __construct()
     {
         $this->setVariablePrefix('place_autocomplete');
@@ -399,21 +394,5 @@ class Autocomplete implements VariableAwareInterface
     public function removeLibrary($library)
     {
         unset($this->libraries[array_search($library, $this->libraries, true)]);
-    }
-
-    /**
-     * @return string
-     */
-    public function getLanguage()
-    {
-        return $this->language;
-    }
-
-    /**
-     * @param string $language
-     */
-    public function setLanguage($language)
-    {
-        $this->language = $language;
     }
 }

--- a/tests/Helper/Builder/ApiHelperBuilderTest.php
+++ b/tests/Helper/Builder/ApiHelperBuilderTest.php
@@ -38,6 +38,18 @@ class ApiHelperBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(AbstractHelperBuilder::class, $this->apiHelperBuilder);
     }
 
+    public function testDefaultState()
+    {
+        $this->assertSame('en', $this->apiHelperBuilder->getLanguage());
+    }
+
+    public function testLanguage()
+    {
+        $this->apiHelperBuilder->setLanguage($language = 'fr');
+
+        $this->assertSame($language, $this->apiHelperBuilder->getLanguage());
+    }
+
     public function testBuild()
     {
         $this->assertInstanceOf(ApiHelper::class, $this->apiHelperBuilder->build());

--- a/tests/Helper/Event/ApiEventTest.php
+++ b/tests/Helper/Event/ApiEventTest.php
@@ -48,7 +48,6 @@ class ApiEventTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertTrue($this->apiEvent->hasObjects());
         $this->assertSame($this->objects, $this->apiEvent->getObjects());
-        $this->assertSame('en', $this->apiEvent->getLanguage());
         $this->assertFalse($this->apiEvent->hasSources());
         $this->assertEmpty($this->apiEvent->getSources());
         $this->assertFalse($this->apiEvent->hasLibraries());
@@ -66,13 +65,6 @@ class ApiEventTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($this->apiEvent->hasObjects(Map::class));
         $this->assertEmpty($this->apiEvent->getObjects(Map::class));
-    }
-
-    public function testLanguage()
-    {
-        $this->apiEvent->setLanguage($language = 'fr');
-
-        $this->assertSame($language, $this->apiEvent->getLanguage());
     }
 
     public function testSetSources()

--- a/tests/Helper/Functional/MapFunctionalTest.php
+++ b/tests/Helper/Functional/MapFunctionalTest.php
@@ -44,15 +44,6 @@ class MapFunctionalTest extends AbstractMapFunctionalTest
         $this->assertMap($map);
     }
 
-    public function testRenderWithLanguage()
-    {
-        $map = new Map();
-        $map->setLanguage('fr');
-
-        $this->renderMap($map);
-        $this->assertMap($map);
-    }
-
     public function testRenderWithMapOptions()
     {
         $map = new Map();

--- a/tests/Helper/Functional/Place/AutocompleteFunctionalTest.php
+++ b/tests/Helper/Functional/Place/AutocompleteFunctionalTest.php
@@ -84,15 +84,6 @@ class AutocompleteFunctionalTest extends AbstractAutocompleteFunctionalTest
         $this->assertAutocomplete($autocomplete);
     }
 
-    public function testRenderWithLanguage()
-    {
-        $autocomplete = $this->createAutocomplete();
-        $autocomplete->setLanguage('fr');
-
-        $this->renderAutocomplete($autocomplete);
-        $this->assertAutocomplete($autocomplete);
-    }
-
     /**
      * @return Autocomplete
      */

--- a/tests/Helper/Renderer/ApiRendererTest.php
+++ b/tests/Helper/Renderer/ApiRendererTest.php
@@ -83,7 +83,6 @@ class ApiRendererTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(
             'function ivory_google_map_load(){google.load("maps","3",{"other_params":"language=en&libraries=library1,library2","callback":ivory_google_map_init})};function ivory_google_map_init_source(src){var script=document.createElement("script");script.type="text/javascript";script.async=true;script.src=src;document.getElementsByTagName("head")[0].appendChild(script);};function ivory_google_map_init_requirement(c,r){if(r()){c();}else{var i=setInterval(function(){if(r()){clearInterval(i);c();}},100);}};function ivory_google_map_init(){ivory_google_map_init_source("source1");ivory_google_map_init_source("source2");ivory_google_map_init_requirement(main_callback,function(){return requirement1&&requirement2;});};ivory_google_map_init_source("https://www.google.com/jsapi?callback=ivory_google_map_load");',
             $this->apiRenderer->render(
-                'en',
                 $this->createCallbacks($object = new \stdClass()),
                 $this->createRequirements($object),
                 ['source1', 'source2'],
@@ -133,7 +132,6 @@ ivory_google_map_init_source("https://www.google.com/jsapi?callback=ivory_google
 EOF;
 
         $this->assertSame($expected, $this->apiRenderer->render(
-            'en',
             $this->createCallbacks($object = new \stdClass()),
             $this->createRequirements($object),
             ['source1', 'source2'],

--- a/tests/Helper/Renderer/LoaderRendererTest.php
+++ b/tests/Helper/Renderer/LoaderRendererTest.php
@@ -39,16 +39,40 @@ class LoaderRendererTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(AbstractJsonRenderer::class, $this->loaderRenderer);
     }
 
+    public function testDefaultState()
+    {
+        $this->assertSame('en', $this->loaderRenderer->getLanguage());
+    }
+
+    public function testInitialState()
+    {
+        $this->loaderRenderer = new LoaderRenderer(new Formatter(), new JsonBuilder(), $language = 'fr');
+
+        $this->assertSame($language, $this->loaderRenderer->getLanguage());
+    }
+
+    public function testLanguage()
+    {
+        $this->loaderRenderer->setLanguage($language = 'fr');
+
+        $this->assertSame($language, $this->loaderRenderer->getLanguage());
+    }
+
     public function testRender()
     {
         $this->assertSame(
             'function name(){google.load("maps","3",{"other_params":"language=en&libraries=library1,library2","callback":callback})};',
-            $this->loaderRenderer->render(
-                'name',
-                'callback',
-                'en',
-                ['library1', 'library2']
-            )
+            $this->loaderRenderer->render('name', 'callback', ['library1', 'library2'])
+        );
+    }
+
+    public function testRenderWithLanguage()
+    {
+        $this->loaderRenderer->setLanguage('fr');
+
+        $this->assertSame(
+            'function name(){google.load("maps","3",{"other_params":"language=fr","callback":callback})};',
+            $this->loaderRenderer->render('name', 'callback')
         );
     }
 
@@ -69,7 +93,6 @@ EOF;
         $this->assertSame($expected, $this->loaderRenderer->render(
             'name',
             'callback',
-            'en',
             ['library1', 'library2']
         ));
     }

--- a/tests/MapTest.php
+++ b/tests/MapTest.php
@@ -56,7 +56,6 @@ class MapTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(LayerManager::class, $this->map->getLayerManager());
         $this->assertFalse($this->map->hasLibraries());
         $this->assertEmpty($this->map->getLibraries());
-        $this->assertSame('en', $this->map->getLanguage());
         $this->assertFalse($this->map->hasMapOptions());
         $this->assertEmpty($this->map->getMapOptions());
         $this->assertFalse($this->map->hasStylesheetOptions());
@@ -199,13 +198,6 @@ class MapTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->map->hasLibraries());
         $this->assertFalse($this->map->hasLibrary($library));
         $this->assertEmpty($this->map->getLibraries());
-    }
-
-    public function testLanguage()
-    {
-        $this->map->setLanguage($language = 'fr');
-
-        $this->assertSame($language, $this->map->getLanguage());
     }
 
     public function testSetMapOptions()

--- a/tests/Place/AutocompleteTest.php
+++ b/tests/Place/AutocompleteTest.php
@@ -56,7 +56,6 @@ class AutocompleteTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($this->autocomplete->getInputAttributes());
         $this->assertFalse($this->autocomplete->hasLibraries());
         $this->assertEmpty($this->autocomplete->getLibraries());
-        $this->assertSame('en', $this->autocomplete->getLanguage());
     }
 
     public function testInputId()
@@ -250,13 +249,6 @@ class AutocompleteTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->autocomplete->hasLibraries());
         $this->assertFalse($this->autocomplete->hasLibrary($library));
         $this->assertEmpty($this->autocomplete->getLibraries());
-    }
-
-    public function testLanguage()
-    {
-        $this->autocomplete->setLanguage($language = 'fr');
-
-        $this->assertSame($language, $this->autocomplete->getLanguage());
     }
 
     /**


### PR DESCRIPTION
This PR moves the language from the map/autocomplete to the loader renderer. Since, the language is confingured on the API loading and is not part of the map or autocomplete; it makes more sense to move it in a common place.