### PR TITLE
[Map] Remove bidirectionality with manager when not needed

### DIFF
--- a/src/Control/ControlManager.php
+++ b/src/Control/ControlManager.php
@@ -11,18 +11,11 @@
 
 namespace Ivory\GoogleMap\Control;
 
-use Ivory\GoogleMap\Map;
-
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
 class ControlManager
 {
-    /**
-     * @var Map|null
-     */
-    private $map;
-
     /**
      * @var MapTypeControl|null
      */
@@ -47,34 +40,6 @@ class ControlManager
      * @var ZoomControl|null
      */
     private $zoomControl;
-
-    /**
-     * @return bool
-     */
-    public function hasMap()
-    {
-        return $this->map !== null;
-    }
-
-    /**
-     * @return Map|null
-     */
-    public function getMap()
-    {
-        return $this->map;
-    }
-
-    /**
-     * @param Map $map
-     */
-    public function setMap(Map $map)
-    {
-        $this->map = $map;
-
-        if ($map->getControlManager() !== $this) {
-            $map->setControlManager($this);
-        }
-    }
 
     /**
      * @return bool

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -11,8 +11,6 @@
 
 namespace Ivory\GoogleMap\Event;
 
-use Ivory\GoogleMap\Map;
-
 /**
  * @see http://code.google.com/apis/maps/documentation/javascript/reference.html#MapsEventListener
  *
@@ -20,11 +18,6 @@ use Ivory\GoogleMap\Map;
  */
 class EventManager
 {
-    /**
-     * @var Map|null
-     */
-    private $map;
-
     /**
      * @var Event[]
      */
@@ -44,34 +37,6 @@ class EventManager
      * @var Event[]
      */
     private $eventsOnce = [];
-
-    /**
-     * @return bool
-     */
-    public function hasMap()
-    {
-        return $this->map !== null;
-    }
-
-    /**
-     * @return Map|null
-     */
-    public function getMap()
-    {
-        return $this->map;
-    }
-
-    /**
-     * @param Map $map
-     */
-    public function setMap(Map $map)
-    {
-        $this->map = $map;
-
-        if ($map->getEventManager() !== $this) {
-            $map->setEventManager($this);
-        }
-    }
 
     /**
      * @return bool

--- a/src/Layer/LayerManager.php
+++ b/src/Layer/LayerManager.php
@@ -11,50 +11,15 @@
 
 namespace Ivory\GoogleMap\Layer;
 
-use Ivory\GoogleMap\Map;
-
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
 class LayerManager
 {
     /**
-     * @var Map|null
-     */
-    private $map;
-
-    /**
      * @var KmlLayer[]
      */
     private $kmlLayers = [];
-
-    /**
-     * @return bool
-     */
-    public function hasMap()
-    {
-        return $this->map !== null;
-    }
-
-    /**
-     * @return Map|null
-     */
-    public function getMap()
-    {
-        return $this->map;
-    }
-
-    /**
-     * @param Map $map
-     */
-    public function setMap(Map $map)
-    {
-        $this->map = $map;
-
-        if ($map->getLayerManager() !== $this) {
-            $map->setLayerManager($this);
-        }
-    }
 
     /**
      * @return bool

--- a/src/Map.php
+++ b/src/Map.php
@@ -173,10 +173,6 @@ class Map implements VariableAwareInterface
     public function setControlManager(ControlManager $controlManager)
     {
         $this->controlManager = $controlManager;
-
-        if ($controlManager->getMap() !== $this) {
-            $controlManager->setMap($this);
-        }
     }
 
     /**
@@ -193,10 +189,6 @@ class Map implements VariableAwareInterface
     public function setEventManager(EventManager $eventManager)
     {
         $this->eventManager = $eventManager;
-
-        if ($eventManager->getMap() !== $this) {
-            $eventManager->setMap($this);
-        }
     }
 
     /**
@@ -213,10 +205,6 @@ class Map implements VariableAwareInterface
     public function setLayerManager(LayerManager $layerManager)
     {
         $this->layerManager = $layerManager;
-
-        if ($layerManager->getMap() !== $this) {
-            $layerManager->setMap($this);
-        }
     }
 
     /**

--- a/tests/Control/ControlManagerTest.php
+++ b/tests/Control/ControlManagerTest.php
@@ -17,7 +17,6 @@ use Ivory\GoogleMap\Control\RotateControl;
 use Ivory\GoogleMap\Control\ScaleControl;
 use Ivory\GoogleMap\Control\StreetViewControl;
 use Ivory\GoogleMap\Control\ZoomControl;
-use Ivory\GoogleMap\Map;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
@@ -39,8 +38,6 @@ class ControlManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaultState()
     {
-        $this->assertFalse($this->controlManager->hasMap());
-        $this->assertNull($this->controlManager->getMap());
         $this->assertFalse($this->controlManager->hasMapTypeControl());
         $this->assertNull($this->controlManager->getMapTypeControl());
         $this->assertFalse($this->controlManager->hasRotateControl());
@@ -51,25 +48,6 @@ class ControlManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($this->controlManager->getStreetViewControl());
         $this->assertFalse($this->controlManager->hasZoomControl());
         $this->assertNull($this->controlManager->getZoomControl());
-    }
-
-    public function testMap()
-    {
-        $map = $this->createMapMock();
-        $map
-            ->expects($this->once())
-            ->method('getControlManager')
-            ->will($this->returnValue(null));
-
-        $map
-            ->expects($this->once())
-            ->method('setControlManager')
-            ->with($this->identicalTo($this->controlManager));
-
-        $this->controlManager->setMap($map);
-
-        $this->assertTrue($this->controlManager->hasMap());
-        $this->assertSame($map, $this->controlManager->getMap());
     }
 
     public function testMapTypeControl()
@@ -155,14 +133,6 @@ class ControlManagerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($this->controlManager->hasZoomControl());
         $this->assertNull($this->controlManager->getZoomControl());
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|Map
-     */
-    private function createMapMock()
-    {
-        return $this->createMock(Map::class);
     }
 
     /**

--- a/tests/Event/EventManagerTest.php
+++ b/tests/Event/EventManagerTest.php
@@ -13,7 +13,6 @@ namespace Ivory\Tests\GoogleMap\Event;
 
 use Ivory\GoogleMap\Event\Event;
 use Ivory\GoogleMap\Event\EventManager;
-use Ivory\GoogleMap\Map;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
@@ -35,8 +34,6 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaultState()
     {
-        $this->assertFalse($this->eventManager->hasMap());
-        $this->assertNull($this->eventManager->getMap());
         $this->assertFalse($this->eventManager->hasDomEvents());
         $this->assertEmpty($this->eventManager->getDomEvents());
         $this->assertFalse($this->eventManager->hasDomEventsOnce());
@@ -45,25 +42,6 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($this->eventManager->getEvents());
         $this->assertFalse($this->eventManager->hasEventsOnce());
         $this->assertEmpty($this->eventManager->getEventsOnce());
-    }
-
-    public function testMap()
-    {
-        $map = $this->createMapMock();
-        $map
-            ->expects($this->once())
-            ->method('getEventManager')
-            ->will($this->returnValue(null));
-
-        $map
-            ->expects($this->once())
-            ->method('setEventManager')
-            ->with($this->identicalTo($this->eventManager));
-
-        $this->eventManager->setMap($map);
-
-        $this->assertTrue($this->eventManager->hasMap());
-        $this->assertSame($map, $this->eventManager->getMap());
     }
 
     public function testSetDomEvents()
@@ -222,14 +200,6 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->eventManager->hasEventsOnce());
         $this->assertFalse($this->eventManager->hasEventOnce($eventOnce));
         $this->assertEmpty($this->eventManager->getEventsOnce());
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|Map
-     */
-    private function createMapMock()
-    {
-        return $this->createMock(Map::class);
     }
 
     /**

--- a/tests/Layer/LayerManagerTest.php
+++ b/tests/Layer/LayerManagerTest.php
@@ -13,7 +13,6 @@ namespace Ivory\Tests\GoogleMap\Layer;
 
 use Ivory\GoogleMap\Layer\KmlLayer;
 use Ivory\GoogleMap\Layer\LayerManager;
-use Ivory\GoogleMap\Map;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
@@ -35,29 +34,8 @@ class LayerManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaultState()
     {
-        $this->assertFalse($this->layerManager->hasMap());
-        $this->assertNull($this->layerManager->getMap());
         $this->assertFalse($this->layerManager->hasKmlLayers());
         $this->assertEmpty($this->layerManager->getKmlLayers());
-    }
-
-    public function testMap()
-    {
-        $map = $this->createMapMock();
-        $map
-            ->expects($this->once())
-            ->method('getLayerManager')
-            ->will($this->returnValue(null));
-
-        $map
-            ->expects($this->once())
-            ->method('setLayerManager')
-            ->with($this->identicalTo($this->layerManager));
-
-        $this->layerManager->setMap($map);
-
-        $this->assertTrue($this->layerManager->hasMap());
-        $this->assertSame($map, $this->layerManager->getMap());
     }
 
     public function testSetKmlLayers()
@@ -96,14 +74,6 @@ class LayerManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->layerManager->hasKmlLayers());
         $this->assertFalse($this->layerManager->hasKmlLayer($kmlLayer));
         $this->assertEmpty($this->layerManager->getKmlLayers());
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|Map
-     */
-    private function createMapMock()
-    {
-        return $this->createMock(Map::class);
     }
 
     /**

--- a/tests/MapTest.php
+++ b/tests/MapTest.php
@@ -92,54 +92,21 @@ class MapTest extends \PHPUnit_Framework_TestCase
 
     public function testControlManager()
     {
-        $controlManager = $this->createControlManagerMock();
-        $controlManager
-            ->expects($this->once())
-            ->method('getMap')
-            ->will($this->returnValue(null));
-
-        $controlManager
-            ->expects($this->once())
-            ->method('setMap')
-            ->with($this->identicalTo($this->map));
-
-        $this->map->setControlManager($controlManager);
+        $this->map->setControlManager($controlManager = $this->createControlManagerMock());
 
         $this->assertSame($controlManager, $this->map->getControlManager());
     }
 
     public function testEventManager()
     {
-        $eventManager = $this->createEventManagerMock();
-        $eventManager
-            ->expects($this->once())
-            ->method('getMap')
-            ->will($this->returnValue(null));
-
-        $eventManager
-            ->expects($this->once())
-            ->method('setMap')
-            ->with($this->identicalTo($this->map));
-
-        $this->map->setEventManager($eventManager);
+        $this->map->setEventManager($eventManager = $this->createEventManagerMock());
 
         $this->assertSame($eventManager, $this->map->getEventManager());
     }
 
     public function testLayerManager()
     {
-        $layerManager = $this->createLayerManagerMock();
-        $layerManager
-            ->expects($this->once())
-            ->method('getMap')
-            ->will($this->returnValue(null));
-
-        $layerManager
-            ->expects($this->once())
-            ->method('setMap')
-            ->with($this->identicalTo($this->map));
-
-        $this->map->setLayerManager($layerManager);
+        $this->map->setLayerManager($layerManager = $this->createLayerManagerMock());
 
         $this->assertSame($layerManager, $this->map->getLayerManager());
     }


### PR DESCRIPTION
This PR removes the bidirectionality between map and managers when not needed. That will allows us to reuse the event manager in the autocomplete.