### PR TITLE
[Layer] Fix geo json layer

### DIFF
--- a/doc/layer/heatmap_layer.md
+++ b/doc/layer/heatmap_layer.md
@@ -42,6 +42,14 @@ $heatmapLayer = new HeatmapLayer(
 );
 ```
 
+## Configure variable
+
+A variable is automatically generated when creating a heatmap layer but if you want to update it, you can use:
+
+``` php
+$heatmapLayer->setVariable('heatmap_layer');
+```
+
 ## Configure coordinates
 
 If you want to update the heatmap layer coordinates, you can use:

--- a/doc/layer/kml_layer.md
+++ b/doc/layer/kml_layer.md
@@ -25,6 +25,14 @@ $kmlLayer = new KmlLayer(
 );
 ```
 
+## Configure variable
+
+A variable is automatically generated when creating a kml layer but if you want to update it, you can use:
+
+``` php
+$kmlLayer->setVariable('kml_layer');
+```
+
 ## Configure url
 
 If you want to update the kml layer url, you can use:

--- a/src/Helper/Renderer/Layer/GeoJsonLayerRenderer.php
+++ b/src/Helper/Renderer/Layer/GeoJsonLayerRenderer.php
@@ -31,13 +31,9 @@ class GeoJsonLayerRenderer extends AbstractJsonRenderer
         $formatter = $this->getFormatter();
         $jsonBuilder = $this->getJsonBuilder()->setValues($geoJsonLayer->getOptions());
 
-        return $formatter->renderObjectAssignment($geoJsonLayer, $formatter->renderObjectCall(
-            $map,
-            $formatter->renderProperty('data', 'loadGeoJson'),
-            [
-                $formatter->renderEscape($geoJsonLayer->getUrl()),
-                $jsonBuilder->build(),
-            ]
-        ));
+        return $formatter->renderObjectCall($map, $formatter->renderProperty('data', 'loadGeoJson'), [
+            $formatter->renderEscape($geoJsonLayer->getUrl()),
+            $jsonBuilder->build(),
+        ]);
     }
 }

--- a/src/Helper/Renderer/MapContainerRenderer.php
+++ b/src/Helper/Renderer/MapContainerRenderer.php
@@ -38,7 +38,6 @@ class MapContainerRenderer extends AbstractJsonRenderer
             ->setValue('[overlays][marker_images]', [])
             ->setValue('[overlays][markers]', [])
             ->setValue('[overlays][marker_cluster]', null)
-            ->setValue('[layers][geo_json_layers]', [])
             ->setValue('[layers][heatmap_layers]', [])
             ->setValue('[layers][kml_layers]', [])
             ->setValue('[events][dom_events]', [])

--- a/src/Helper/Subscriber/Layer/GeoJsonLayerSubscriber.php
+++ b/src/Helper/Subscriber/Layer/GeoJsonLayerSubscriber.php
@@ -90,12 +90,7 @@ class GeoJsonLayerSubscriber extends AbstractSubscriber
         $map = $event->getMap();
 
         foreach ($this->geoJsonLayerCollector->collect($map) as $geoJsonLayer) {
-            $event->addCode($formatter->renderContainerAssignment(
-                $map,
-                $this->geoJsonLayerRenderer->render($geoJsonLayer, $map),
-                'layers.geo_json_layers',
-                $geoJsonLayer
-            ));
+            $event->addCode($formatter->renderCode($this->geoJsonLayerRenderer->render($geoJsonLayer, $map)));
         }
     }
 

--- a/src/Layer/GeoJsonLayer.php
+++ b/src/Layer/GeoJsonLayer.php
@@ -13,16 +13,13 @@ namespace Ivory\GoogleMap\Layer;
 
 use Ivory\GoogleMap\Utility\OptionsAwareInterface;
 use Ivory\GoogleMap\Utility\OptionsAwareTrait;
-use Ivory\GoogleMap\Utility\VariableAwareInterface;
-use Ivory\GoogleMap\Utility\VariableAwareTrait;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class GeoJsonLayer implements OptionsAwareInterface, VariableAwareInterface
+class GeoJsonLayer implements OptionsAwareInterface
 {
     use OptionsAwareTrait;
-    use VariableAwareTrait;
 
     /**
      * @var string
@@ -35,7 +32,6 @@ class GeoJsonLayer implements OptionsAwareInterface, VariableAwareInterface
      */
     public function __construct($url, array $options = [])
     {
-        $this->setVariablePrefix('geo_json_layer');
         $this->setUrl($url);
         $this->setOptions($options);
     }

--- a/tests/Helper/Functional/AbstractMapFunctionalTest.php
+++ b/tests/Helper/Functional/AbstractMapFunctionalTest.php
@@ -187,7 +187,6 @@ abstract class AbstractMapFunctionalTest extends AbstractApiFunctionalTest
      */
     protected function assertGeoJsonLayer(Map $map, GeoJsonLayer $geoJsonLayer)
     {
-        $this->assertSameContainerVariable($map, 'layers.geo_json_layers', $geoJsonLayer);
     }
 
     /**

--- a/tests/Helper/Renderer/Layer/GeoJsonLayerRendererTest.php
+++ b/tests/Helper/Renderer/Layer/GeoJsonLayerRendererTest.php
@@ -47,10 +47,9 @@ class GeoJsonLayerRendererTest extends \PHPUnit_Framework_TestCase
         $map->setVariable('map');
 
         $geoJsonLayer = new GeoJsonLayer('url', ['foo' => 'bar']);
-        $geoJsonLayer->setVariable('geo_json_layer');
 
         $this->assertSame(
-            'geo_json_layer=map.data.loadGeoJson("url",{"foo":"bar"})',
+            'map.data.loadGeoJson("url",{"foo":"bar"})',
             $this->geoJsonLayerRenderer->render($geoJsonLayer, $map)
         );
     }

--- a/tests/Helper/Renderer/MapContainerRendererTest.php
+++ b/tests/Helper/Renderer/MapContainerRendererTest.php
@@ -42,7 +42,7 @@ class MapContainerRendererTest extends \PHPUnit_Framework_TestCase
     public function testRender()
     {
         $this->assertSame(
-            '{"base":{"coordinates":[],"bounds":[],"points":[],"sizes":[]},"map":null,"overlays":{"circles":[],"encoded_polylines":[],"ground_overlays":[],"polygons":[],"polylines":[],"rectangles":[],"info_windows":[],"info_boxes":[],"marker_images":[],"markers":[],"marker_cluster":null},"layers":{"geo_json_layers":[],"heatmap_layers":[],"kml_layers":[]},"events":{"dom_events":[],"dom_events_once":[],"events":[],"events_once":[]},"functions":[]}',
+            '{"base":{"coordinates":[],"bounds":[],"points":[],"sizes":[]},"map":null,"overlays":{"circles":[],"encoded_polylines":[],"ground_overlays":[],"polygons":[],"polylines":[],"rectangles":[],"info_windows":[],"info_boxes":[],"marker_images":[],"markers":[],"marker_cluster":null},"layers":{"heatmap_layers":[],"kml_layers":[]},"events":{"dom_events":[],"dom_events_once":[],"events":[],"events_once":[]},"functions":[]}',
             $this->mapContainerRenderer->render()
         );
     }
@@ -74,7 +74,6 @@ class MapContainerRendererTest extends \PHPUnit_Framework_TestCase
         "marker_cluster": null
     },
     "layers": {
-        "geo_json_layers": [],
         "heatmap_layers": [],
         "kml_layers": []
     },

--- a/tests/Layer/GeoJsonLayerTest.php
+++ b/tests/Layer/GeoJsonLayerTest.php
@@ -13,7 +13,6 @@ namespace Ivory\Tests\GoogleMap\Layer;
 
 use Ivory\GoogleMap\Layer\GeoJsonLayer;
 use Ivory\GoogleMap\Utility\OptionsAwareInterface;
-use Ivory\GoogleMap\Utility\VariableAwareInterface;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
@@ -41,12 +40,10 @@ class GeoJsonLayerTest extends \PHPUnit_Framework_TestCase
     public function testInheritance()
     {
         $this->assertInstanceOf(OptionsAwareInterface::class, $this->geoJsonLayer);
-        $this->assertInstanceOf(VariableAwareInterface::class, $this->geoJsonLayer);
     }
 
     public function testDefaultState()
     {
-        $this->assertStringStartsWith('geo_json_layer', $this->geoJsonLayer->getVariable());
         $this->assertSame($this->url, $this->geoJsonLayer->getUrl());
         $this->assertFalse($this->geoJsonLayer->hasOptions());
     }


### PR DESCRIPTION
This PR fixes the geo json handling. Since `map.data.loadGeoJson` does not return anything, we don't need to implement the `VariableAwareInterface`.