### PR TITLE
[Geocoder] Drop 'willdurand/geocoder' dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,11 @@
         "php-http/message": "^1.3",
         "phpunit/phpunit": "^5.4",
         "phpunit/phpunit-selenium": "^3.0",
-        "symfony/cache": "^3.0",
-        "willdurand/geocoder": "^3.0"
+        "symfony/cache": "^3.0"
     },
     "suggest": {
         "php-http/client-implementation": "Allows to use http services",
-        "php-http/message": "Allows to use http services",
-        "willdurand/geocoder": "Allows to use geocoder service"
+        "php-http/message": "Allows to use http services"
     },
     "autoload": {
         "psr-4": { "Ivory\\GoogleMap\\": "src/" }

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -23,14 +23,8 @@ $ composer require egeloen/google-map
 
 ## Download additional libraries
 
-If you want to use the Geocoder service, you will need [Geocoder](http://github.com/willdurand/Geocoder):
-
-``` bash
-$ composer require willdurand/geocoder
-```
-
-If you want to use the [Direction](/doc/service/geocoder/direction.md), 
-[Distance Matrix](/doc/service/geocoder/distance-matrix.md), [Elevation](/doc/service/elevation/elevation.md),
+If you want to use the [Direction](/doc/service/direction/direction.md), 
+[Distance Matrix](/doc/service/distance_matrix/distance_matrix.md), [Elevation](/doc/service/elevation/elevation.md),
 [Geocoder](/doc/service/geocoder/geocoder.md), [Time Zone](/doc/service/time_zone/time_zone.md) services, you will need 
 an http client and message factory via [Httplug](http://httplug.io/) which is an http client abstraction library:
 

--- a/doc/service/geocoder/geocoder.md
+++ b/doc/service/geocoder/geocoder.md
@@ -7,28 +7,19 @@ process is known as "reverse geocoding".
 
 ## Dependencies
 
-The Geocoder API uses [Geocoder](http://github.com/willdurand/Geocoder) which is the most popular PHP Geocoder. So, 
-first, I recommend you to read its documentation. To install it, read this [documentation](/doc/installation.md).
-
-It also requires an http client and so, the library relies on [Httplug](http://httplug.io/) which is an http 
-client abstraction library. To install it, read this [documentation](/doc/installation.md).
-
-## Why an other Geocoder?
-
-The Geocoder shipped with the library is not an other Geocoder but an extension of the most popular 
-[Geocoder](http://github.com/willdurand/Geocoder). The main difference is instead of giving you a typical response, 
-it returns a custom once wrapping Ivory objects allowing you to more easily reuse them. 
+The Geocoder API requires an http client and so, the library relies on [Httplug](http://httplug.io/) which is an 
+http client abstraction library. To install it, read this [documentation](/doc/installation.md).
 
 ## Build
 
 First of all, if you want to geocode a position, you will need to build a geocoder provider. So let's go:
 
 ``` php
-use Ivory\GoogleMap\Service\Geocoder\GeocoderProvider;
+use Ivory\GoogleMap\Service\Geocoder\Geocoder;
 use Http\Adapter\Guzzle6\Client;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
 
-$geocoder = new GeocoderProvider(new Client(), new GuzzleMessageFactory());
+$geocoder = new Geocoder(new Client(), new GuzzleMessageFactory());
 ```
 
 The geocoder provider constructor requires an `HttpClient` as first argument and a `MessageFactory` as second argument. 
@@ -43,9 +34,10 @@ All services works the same way, so, if you want to learn more about it, you can
 Once you have built you geocoder provider, you can geocode a position or an address:
 
 ``` php
-$response = $geocoder->geocode('1600 Amphitheatre Parkway, Mountain View, CA');
-// or
-$response = $geocoder->reverse(48.865475, 2.321118);
+use Ivory\GoogleMap\Service\Geocoder\Request\GeocoderAddressRequest;
+
+$request = new GeocoderAddressRequest('1600 Amphitheatre Parkway, Mountain View, CA');
+$response = $geocoder->geocode($request);
 ```
 
 The geocoder provider allows you to geocoder a much more advance request. If you want to learn more about it, you can 

--- a/doc/service/geocoder/geocoder_request.md
+++ b/doc/service/geocoder/geocoder_request.md
@@ -1,16 +1,7 @@
 # Geocoder Request
 
-If you just want to geocode a simple string or a coordinate you don't need to build a request, you can directly use the 
-built-in Geocoder API:
-
-``` php
-$response = $geocoder->geocode('1600 Amphitheatre Parkway, Mountain View, CA');
-// or
-$response = $geocoder->reverse(48.865475, 2.321118);
-```
-
-This is already nice but it does not provide as much features as Google provide. The geocoder provider also supports 
-three specialized request which allows you to geocode a much more advanced location.
+Depending on what you want to geocode, you need to choose the appropriate request. The library allows you to geocode
+from an address, a coordinate or a place id.
 
 ## Address request
 

--- a/tests/Service/Geocoder/GeocoderApiKeyTest.php
+++ b/tests/Service/Geocoder/GeocoderApiKeyTest.php
@@ -12,7 +12,7 @@
 namespace Ivory\Tests\GoogleMap\Service\Geocoder;
 
 use Ivory\GoogleMap\Base\Coordinate;
-use Ivory\GoogleMap\Service\Geocoder\GeocoderProvider;
+use Ivory\GoogleMap\Service\Geocoder\Geocoder;
 use Ivory\GoogleMap\Service\Geocoder\Request\GeocoderAddressType;
 use Ivory\GoogleMap\Service\Geocoder\Request\GeocoderCoordinateRequest;
 use Ivory\GoogleMap\Service\Geocoder\Request\GeocoderPlaceIdRequest;
@@ -22,10 +22,10 @@ use Ivory\Tests\GoogleMap\Service\AbstractServiceTest;
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class GeocoderProviderApiKeyTest extends AbstractServiceTest
+class GeocoderApiKeyTest extends AbstractServiceTest
 {
     /**
-     * @var GeocoderProvider
+     * @var Geocoder
      */
     private $geocoder;
 
@@ -42,7 +42,7 @@ class GeocoderProviderApiKeyTest extends AbstractServiceTest
 
         parent::setUp();
 
-        $this->geocoder = new GeocoderProvider($this->getClient(), $this->getMessageFactory());
+        $this->geocoder = new Geocoder($this->getClient(), $this->getMessageFactory());
         $this->geocoder->setKey($_SERVER['API_KEY']);
     }
 

--- a/tests/Service/Geocoder/GeocoderTest.php
+++ b/tests/Service/Geocoder/GeocoderTest.php
@@ -16,7 +16,7 @@ use Http\Message\MessageFactory;
 use Ivory\GoogleMap\Base\Bound;
 use Ivory\GoogleMap\Base\Coordinate;
 use Ivory\GoogleMap\Service\BusinessAccount;
-use Ivory\GoogleMap\Service\Geocoder\GeocoderProvider;
+use Ivory\GoogleMap\Service\Geocoder\Geocoder;
 use Ivory\GoogleMap\Service\Geocoder\Request\AbstractGeocoderRequest;
 use Ivory\GoogleMap\Service\Geocoder\Request\GeocoderAddressRequest;
 use Ivory\GoogleMap\Service\Geocoder\Request\GeocoderComponentType;
@@ -30,10 +30,10 @@ use Psr\Http\Message\StreamInterface;
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
-class GeocoderProviderTest extends AbstractServiceTest
+class GeocoderTest extends AbstractServiceTest
 {
     /**
-     * @var GeocoderProvider
+     * @var Geocoder
      */
     private $geocoder;
 
@@ -46,37 +46,7 @@ class GeocoderProviderTest extends AbstractServiceTest
 
         parent::setUp();
 
-        $this->geocoder = new GeocoderProvider($this->getClient(), $this->getMessageFactory());
-    }
-
-    public function testLimit()
-    {
-        $this->geocoder->limit($limit = 1);
-
-        $this->assertSame($limit, $this->geocoder->getLimit());
-    }
-
-    public function testLocale()
-    {
-        $this->geocoder->setLocale($locale = 'fr');
-
-        $this->assertSame($locale, $this->geocoder->getLocale());
-    }
-
-    public function testGeocode()
-    {
-        $response = $this->geocoder->geocode('Paris');
-
-        $this->assertSame(GeocoderStatus::OK, $response->getStatus());
-        $this->assertNotEmpty($response->getResults());
-    }
-
-    public function testGeocodeIp()
-    {
-        $response = $this->geocoder->geocode('66.249.64.1');
-
-        $this->assertSame(GeocoderStatus::OK, $response->getStatus());
-        $this->assertNotEmpty($response->getResults());
+        $this->geocoder = new Geocoder($this->getClient(), $this->getMessageFactory());
     }
 
     public function testGeocodeAddress()
@@ -158,7 +128,7 @@ class GeocoderProviderTest extends AbstractServiceTest
     {
         $this->geocoder->setHttps(false);
 
-        $response = $this->geocoder->geocode('Paris');
+        $response = $this->geocoder->geocode($this->createRequest());
 
         $this->assertSame(GeocoderStatus::OK, $response->getStatus());
         $this->assertNotEmpty($response->getResults());
@@ -166,29 +136,9 @@ class GeocoderProviderTest extends AbstractServiceTest
 
     public function testGeocodeWithXmlFormat()
     {
-        $this->geocoder->setFormat(GeocoderProvider::FORMAT_XML);
+        $this->geocoder->setFormat(Geocoder::FORMAT_XML);
 
-        $response = $this->geocoder->geocode('Paris');
-
-        $this->assertSame(GeocoderStatus::OK, $response->getStatus());
-        $this->assertNotEmpty($response->getResults());
-    }
-
-    public function testGeocodeWithLimit()
-    {
-        $this->geocoder->limit(1);
-
-        $response = $this->geocoder->geocode('Chelsea, New York, NY, USA');
-
-        $this->assertSame(GeocoderStatus::OK, $response->getStatus());
-        $this->assertCount(1, $response->getResults());
-    }
-
-    public function testGeocodeWithLocale()
-    {
-        $this->geocoder->setLocale('fr');
-
-        $response = $this->geocoder->geocode('Paris');
+        $response = $this->geocoder->geocode($this->createRequest());
 
         $this->assertSame(GeocoderStatus::OK, $response->getStatus());
         $this->assertNotEmpty($response->getResults());
@@ -196,7 +146,7 @@ class GeocoderProviderTest extends AbstractServiceTest
 
     public function testGeocodeWithKey()
     {
-        $this->geocoder = new GeocoderProvider(
+        $this->geocoder = new Geocoder(
             $client = $this->createHttpClientMock(),
             $messageFactory = $this->createMessageFactoryMock()
         );
@@ -244,7 +194,7 @@ class GeocoderProviderTest extends AbstractServiceTest
 
     public function testGeocodeWithBusinessAccount()
     {
-        $this->geocoder = new GeocoderProvider(
+        $this->geocoder = new Geocoder(
             $client = $this->createHttpClientMock(),
             $messageFactory = $this->createMessageFactoryMock()
         );
@@ -295,29 +245,6 @@ class GeocoderProviderTest extends AbstractServiceTest
 
         $this->assertSame(GeocoderStatus::OK, $response->getStatus());
         $this->assertEmpty($response->getResults());
-    }
-
-    public function testReverse()
-    {
-        $response = $this->geocoder->reverse(48.856633, 2.352254);
-
-        $this->assertSame(GeocoderStatus::OK, $response->getStatus());
-        $this->assertNotEmpty($response->getResults());
-    }
-
-    public function testReverseWithXmlFormat()
-    {
-        $this->geocoder->setFormat(GeocoderProvider::FORMAT_XML);
-
-        $response = $this->geocoder->reverse(48.856633, 2.352254);
-
-        $this->assertSame(GeocoderStatus::OK, $response->getStatus());
-        $this->assertNotEmpty($response->getResults());
-    }
-
-    public function testName()
-    {
-        $this->assertSame('ivory_google_map', $this->geocoder->getName());
     }
 
     /**


### PR DESCRIPTION
The geocoder dependency does not make sense since the goal of this library is to provide an common API for multiple providers, it does not fit the purpose of the built-in geocoder which is to provide Ivory objects (reusable in the map).