### PR TITLE
[Helper] Fix custom control rendering

### DIFF
--- a/src/Helper/Builder/MapHelperBuilder.php
+++ b/src/Helper/Builder/MapHelperBuilder.php
@@ -99,6 +99,7 @@ use Ivory\GoogleMap\Helper\Subscriber\Base\BoundSubscriber;
 use Ivory\GoogleMap\Helper\Subscriber\Base\CoordinateSubscriber;
 use Ivory\GoogleMap\Helper\Subscriber\Base\PointSubscriber;
 use Ivory\GoogleMap\Helper\Subscriber\Base\SizeSubscriber;
+use Ivory\GoogleMap\Helper\Subscriber\Control\ControlSubscriber;
 use Ivory\GoogleMap\Helper\Subscriber\Control\CustomControlSubscriber;
 use Ivory\GoogleMap\Helper\Subscriber\Event\DomEventOnceSubscriber;
 use Ivory\GoogleMap\Helper\Subscriber\Event\DomEventSubscriber;
@@ -343,6 +344,7 @@ class MapHelperBuilder extends AbstractHelperBuilder
             new SizeSubscriber($formatter, $sizeCollector, $sizeRenderer),
 
             // Control
+            new ControlSubscriber($formatter),
             new CustomControlSubscriber($formatter, $customControlCollector, $customControlRenderer),
 
             // Event

--- a/tests/Helper/Functional/CompoundFunctionalTest.php
+++ b/tests/Helper/Functional/CompoundFunctionalTest.php
@@ -11,6 +11,8 @@
 
 namespace Ivory\Tests\GoogleMap\Helper\Functional;
 
+use Ivory\GoogleMap\Control\ControlPosition;
+use Ivory\GoogleMap\Control\CustomControl;
 use Ivory\GoogleMap\Helper\Builder\MapHelperBuilder;
 use Ivory\GoogleMap\Helper\Builder\PlaceAutocompleteHelperBuilder;
 use Ivory\GoogleMap\Helper\MapHelper;
@@ -48,7 +50,17 @@ class CompoundFunctionalTest extends AbstractApiFunctionalTest
 
     public function testRender()
     {
-        $this->render(new Autocomplete(), new Map());
+        $autocomplete = new Autocomplete();
+
+        $control = new CustomControl(
+            ControlPosition::RIGHT_TOP,
+            'return document.getElementById("'.$autocomplete->getHtmlId().'")'
+        );
+
+        $map = new Map();
+        $map->getControlManager()->addCustomControl($control);
+
+        $this->render($autocomplete, $map);
     }
 
     /**


### PR DESCRIPTION
This PR fixes custom control rendering. It seems the bundle is not affected by this bug since the `ControlSubscriber` is already registered (see [here](https://github.com/egeloen/IvoryGoogleMapBundle/blob/master/Resources/config/helper/subscriber.xml#L75-L81))

It also show how to transform a place autocomplete into a map control.