### PR TITLE
patch parse error

### DIFF
--- a/src/Helper/Collector/Overlay/InfoWindowCollector.php
+++ b/src/Helper/Collector/Overlay/InfoWindowCollector.php
@@ -85,8 +85,13 @@ class InfoWindowCollector extends AbstractCollector
     public function collect(
         Map $map,
         array $infoWindows = [],
-        $strategy = self::STRATEGY_MAP | self::STRATEGY_MARKER
+        $strategy = null
     ) {
+        if (empty($strategy))
+        {
+            $strategy = self::STRATEGY_MAP | self::STRATEGY_MARKER;
+        }
+        
         if ($strategy & self::STRATEGY_MAP) {
             $infoWindows = $this->collectValues($map->getOverlayManager()->getInfoWindows(), $infoWindows);
         }


### PR DESCRIPTION
Proposed patch corrects Parse Error: syntax error, unexpected '|', expecting ')' due to fact that expressions are not accepted in default arguments.