### PR TITLE
Fix POST_CODE const in docs

### DIFF
--- a/doc/service/geocoder/geocoder_address_request.md
+++ b/doc/service/geocoder/geocoder_address_request.md
@@ -32,7 +32,7 @@ If you want to provide component filtering, you can use:
 use Ivory\GoogleMap\Service\Geocoder\Request\GeocoderComponentType;
 
 $request->setComponents([
-    GeocoderComponentType::POST_CODE => 59800,
+    GeocoderComponentType::POSTAL_CODE => 59800,
     GeocoderComponentType::COUNTRY   => 'fr',
 ]);
 ```

--- a/doc/service/place/autocomplete/place_autocomplete_default_request.md
+++ b/doc/service/place/autocomplete/place_autocomplete_default_request.md
@@ -64,7 +64,7 @@ A grouping of places to which you would like to restrict your results:
 use Ivory\GoogleMap\Place\AutocompleteComponentType;
 
 $request->setComponents([
-    AutocompleteComponentType::POST_CODE => 59800,
+    AutocompleteComponentType::POSTAL_CODE => 59800,
     AutocompleteComponentType::COUNTRY   => 'fr',
 ]);
 ```


### PR DESCRIPTION
In documentation I found using of POST_CODE const from GeocoderComponentType class. But there is POSTAL_CODE const.